### PR TITLE
feat: Add max payload size to PayloadAttrs

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -29,6 +29,8 @@ pub trait L2EngineApi {
 pub struct PayloadAttrs {
     pub parent_payload: PayloadId,
     pub events: Vec<SlotEvents<L1Event>>,
+    /// Max payload size in bytes.
+    pub max_payload_size: u32,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
The `PayloadAttrs` struct now includes a new field `max_payload_size` to specify the maximum payload size in bytes.