### PR TITLE
withdrawal

### DIFF
--- a/src/events/l1.rs
+++ b/src/events/l1.rs
@@ -1,32 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use crate::Address;
+use super::Transfer;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum L1Event {
-    Deposit(TxMint),
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct TxMint {
-    pub account: Address,
-    pub amount: u64,
-}
-
-#[cfg(test)]
-mod test {
-    use rand::random;
-
-    use super::*;
-
-    #[test]
-    fn test_serde_tx_mint() {
-        let tx = super::TxMint {
-            account: Address::from(random::<[u8; 32]>()),
-            amount: 100,
-        };
-        let encoded_tx = serde_json::to_string(&tx).unwrap();
-        let decoded_tx: super::TxMint = serde_json::from_str(&encoded_tx).unwrap();
-        assert_eq!(tx, decoded_tx);
-    }
+    Deposit(Transfer),
 }

--- a/src/events/l1.rs
+++ b/src/events/l1.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use super::Transfer;
+use super::Bridge;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum L1Event {
-    Deposit(Transfer),
+    Deposit(Bridge),
 }

--- a/src/events/l2.rs
+++ b/src/events/l2.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use super::Transfer;
+use super::Bridge;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum L2Event {
-    Withdrawal(Transfer),
+    Withdrawal(Bridge),
 }

--- a/src/events/l2.rs
+++ b/src/events/l2.rs
@@ -1,4 +1,8 @@
 use serde::{Deserialize, Serialize};
 
+use super::Transfer;
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub enum L2Event {}
+pub enum L2Event {
+    Withdrawal(Transfer),
+}

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -1,2 +1,30 @@
+use serde::{Deserialize, Serialize};
+
+use crate::Address;
+
 pub mod l1;
 pub mod l2;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Transfer {
+    pub account: Address,
+    pub amount: u64,
+}
+
+#[cfg(test)]
+mod test {
+    use rand::random;
+
+    use super::*;
+
+    #[test]
+    fn test_serde_tx_mint() {
+        let tx = super::Transfer {
+            account: Address::from(random::<[u8; 32]>()),
+            amount: 100,
+        };
+        let encoded_tx = serde_json::to_string(&tx).unwrap();
+        let decoded_tx: super::Transfer = serde_json::from_str(&encoded_tx).unwrap();
+        assert_eq!(tx, decoded_tx);
+    }
+}

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -6,7 +6,7 @@ pub mod l1;
 pub mod l2;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct Transfer {
+pub struct Bridge {
     pub account: Address,
     pub amount: u64,
 }
@@ -19,12 +19,12 @@ mod test {
 
     #[test]
     fn test_serde_tx_mint() {
-        let tx = super::Transfer {
+        let tx = super::Bridge {
             account: Address::from(random::<[u8; 32]>()),
             amount: 100,
         };
         let encoded_tx = serde_json::to_string(&tx).unwrap();
-        let decoded_tx: super::Transfer = serde_json::from_str(&encoded_tx).unwrap();
+        let decoded_tx: super::Bridge = serde_json::from_str(&encoded_tx).unwrap();
         assert_eq!(tx, decoded_tx);
     }
 }


### PR DESCRIPTION
Refactored the event modules `l1.rs` and `l2.rs` to use a common `Transfer` struct for deposit and withdrawal events. This improves code organization and reduces duplication. Also added the `Transfer` struct to the `mod.rs` file for shared usage.